### PR TITLE
fix(build): tolerate optional links + lazy OpenAI client

### DIFF
--- a/src/app/api/the-web/[slug]/iris/route.ts
+++ b/src/app/api/the-web/[slug]/iris/route.ts
@@ -23,7 +23,14 @@ const RequestSchema = z.object({
 
 // Claude for conversation (quality matters), GPT-4o-mini for drafts (just formatting)
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+
+let openaiClient: OpenAI | null = null;
+function getOpenAI(): OpenAI {
+  if (!openaiClient) {
+    openaiClient = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  }
+  return openaiClient;
+}
 
 export async function POST(
   request: NextRequest,
@@ -143,7 +150,7 @@ export async function POST(
   ];
 
   try {
-    const completion = await openai.chat.completions.create({
+    const completion = await getOpenAI().chat.completions.create({
       model: 'gpt-4o-mini',
       messages: draftMessages,
       temperature: 0.7,

--- a/src/app/projects/project_card.tsx
+++ b/src/app/projects/project_card.tsx
@@ -59,16 +59,18 @@ export default function ProjectCard({ project }: ProjectCardProps) {
             {/* Action buttons: hidden on desktop idle, fade in on hover; always visible on mobile */}
             <div className="flex items-center gap-2 flex-shrink-0 mb-1 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity duration-[50ms]">
               <AskIrisButton item={project} type="project" />
-              <a
-                href={project.githubLink}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="GitHub"
-                onClick={(e) => e.stopPropagation()}
-                className="inline-block hover:scale-105 transition-all duration-200 ease-out"
-              >
-                <FaGithub className="w-5 h-5 text-blue-500 dark:text-blue-300 hover:text-blue-700 dark:hover:text-orange-500" />
-              </a>
+              {project.githubLink && (
+                <a
+                  href={project.githubLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="GitHub"
+                  onClick={(e) => e.stopPropagation()}
+                  className="inline-block hover:scale-105 transition-all duration-200 ease-out"
+                >
+                  <FaGithub className="w-5 h-5 text-blue-500 dark:text-blue-300 hover:text-blue-700 dark:hover:text-orange-500" />
+                </a>
+              )}
               {project.projectLink && project.projectLink.length > 0 && (
                 <a
                   href={project.projectLink}

--- a/src/app/work_experience/experience_card.tsx
+++ b/src/app/work_experience/experience_card.tsx
@@ -75,25 +75,41 @@ export default function ExperienceCard({ item }: ExperienceCardProps) {
             </div>
           </div>
           <div className="mb-2 text-sm flex items-center gap-2">
-            <a
-              href={item.companyUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 dark:text-blue-400 hover:underline"
-              onClick={(e) => e.stopPropagation()}
-            >
-              {item.company === "Google" ? (
-                <Image
-                  src="/google-logo.png"
-                  alt="Google"
-                  width={54}
-                  height={18}
-                  className="inline-block align-middle"
-                />
-              ) : (
-                item.company
-              )}
-            </a>
+            {item.companyUrl ? (
+              <a
+                href={item.companyUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 dark:text-blue-400 hover:underline"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {item.company === "Google" ? (
+                  <Image
+                    src="/google-logo.png"
+                    alt="Google"
+                    width={54}
+                    height={18}
+                    className="inline-block align-middle"
+                  />
+                ) : (
+                  item.company
+                )}
+              </a>
+            ) : (
+              <span className="text-gray-700 dark:text-gray-300">
+                {item.company === "Google" ? (
+                  <Image
+                    src="/google-logo.png"
+                    alt="Google"
+                    width={54}
+                    height={18}
+                    className="inline-block align-middle"
+                  />
+                ) : (
+                  item.company
+                )}
+              </span>
+            )}
             {item.isIncoming && (
               <span className="px-2 py-0.5 text-xs font-semibold rounded-full bg-gradient-to-r from-green-100 to-emerald-200 text-green-800 dark:from-green-900 dark:to-emerald-800 dark:text-green-300">
                 Incoming

--- a/src/data/loaders.ts
+++ b/src/data/loaders.ts
@@ -33,7 +33,7 @@ export interface Project {
   title: string;
   shortTitle?: string;  // Optional condensed title for mobile/reduced screen layouts
   description: string;
-  githubLink: string;
+  githubLink?: string;
   projectLink?: string;
   skills?: string[];
 }
@@ -48,7 +48,7 @@ export interface WorkExperience {
   company: string;
   period: string;
   description: string;
-  companyUrl: string;
+  companyUrl?: string;
   skills: string[];
   isIncoming: boolean;  // True if start date is in the future
   /** Map of text snippets to hover card IDs for inline hover triggers */


### PR DESCRIPTION
## Summary
Two stacked causes of the broken build:

- **Type errors in `src/data/loaders.ts`** — `Project.githubLink` and `WorkExperience.companyUrl` were typed as required `string`, but the KB has projects without `links.github` and `exp_olympus_founder` has empty `links`. Made both optional and gated the GitHub / company anchors in `project_card.tsx` and `experience_card.tsx` on link presence (mirroring the existing `projectLink` pattern).
- **OpenAI client constructed at module load** in `src/app/api/the-web/[slug]/iris/route.ts` — the SDK throws when `apiKey` is empty, which broke page-data collection in build envs without `OPENAI_API_KEY` (per `CLAUDE.md`, the key is optional and only used for blog-Iris drafts). Switched to a lazy `getOpenAI()` initializer so it only constructs when the draft branch actually runs.

## Test plan
- [x] `npm run build` — completes successfully through static page generation
- [ ] Verify Vercel production deploy succeeds after merge
- [ ] Spot-check `/projects` and `/work_experience` render and that Olympus card has no broken company link


---
_Generated by [Claude Code](https://claude.ai/code/session_01YPpcmEucJYNUqGBKCu8mrH)_